### PR TITLE
Fixed setup.py 'packages' list that missed 'templatetags' module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     packages=[
         'djangocms_snippet',
         'djangocms_snippet.migrations',
-        'djangocms_snippet.south_migrations'
+        'djangocms_snippet.south_migrations',
+        'djangocms_snippet.templatetags'
     ],
     license='LICENSE.txt',
     platforms=['OS Independent'],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'djangocms_snippet',
         'djangocms_snippet.migrations',
         'djangocms_snippet.south_migrations',
-        'djangocms_snippet.templatetags'
+        'djangocms_snippet.templatetags',
     ],
     license='LICENSE.txt',
     platforms=['OS Independent'],


### PR DESCRIPTION
This fixes trouble in installed egg (maybe the wheel also?) that misses the 'templatetags' module.

This would be worth a new minor package release because actually the latest release on Pypi won't fail install itself but template tags is not available.