### PR TITLE
Adding missing migration for template field of Snippet model.

### DIFF
--- a/djangocms_snippet/migrations/0007_auto_alter_template_helptext.py
+++ b/djangocms_snippet/migrations/0007_auto_alter_template_helptext.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_snippet', '0006_auto_20160831_0729'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='snippet',
+            name='template',
+            field=models.CharField(help_text='Enter a template (e.g. "snippets/plugin_xy.html") to be rendered. If "template" is given, the contents of field "HTML" will be passed as template variable {{ html }} to the template. Otherwise, the content of "HTML" is rendered.', max_length=255, verbose_name='Template', blank=True),
+        ),
+    ]


### PR DESCRIPTION
The helptext for the template field of the Snippet model was modified in the commit https://github.com/divio/djangocms-snippet/commit/fe3e67ecef7511485433d67327fd0e6fcbfa1c5f, but a new migration was never created. This commit creates that missing migration.