### PR TITLE
updated naming and testing infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
   - TOX_ENV=py27-latest
   - TOX_ENV=py34-latest
   # Django 1.8
-  - TOX_ENV=py34-dj18-cms33
-  - TOX_ENV=py34-dj18-cms32
+  - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py27-dj18-cms32
+  - TOX_ENV=py34-dj18-cms34
+  - TOX_ENV=py34-dj18-cms33
   # Django 1.9
-  - TOX_ENV=py34-dj19-cms33
-  - TOX_ENV=py34-dj19-cms32
+  - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py27-dj19-cms32
+  - TOX_ENV=py34-dj19-cms34
+  - TOX_ENV=py34-dj19-cms33
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 =========
 
 
+1.9.2 (unreleased)
+==================
+
+* Changed naming of ``Aldryn`` to ``Divio Cloud``
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.4 and dropped 3.2
+
+
 1.9.1 (2016-09-08)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django CMS Snippet
 **django CMS Snippet** provides a plugin for `django CMS <http://django-cms.org>`_
 to inject HTML, CSS or JavaScript snippets into your website.
 
-This addon is compatible with `Aldryn <http://aldryn.com>`_ and is also available on the
+This addon is compatible with `Divio Cloud <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-snippet/>`_
 for easy installation.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{34,27}-latest
-    py{34,27}-dj18-cms{33,32}
-    py{34,27}-dj19-cms{33,32}
+    py{34,27}-dj18-cms{34,33}
+    py{34,27}-dj19-cms{34,33}
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,8 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     latest: django-cms
-    cms32: django-cms>=3.2,<3.3
     cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2