### PR TITLE
Release version 1.9.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.9.2 (unreleased)
+1.9.2 (2016-11-22)
 ==================
 
 * Changed naming of ``Aldryn`` to ``Divio Cloud``

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.9.1'
+__version__ = '1.9.2'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'


### PR DESCRIPTION
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2
* Updated translations