### PR TITLE
print full exception message

### DIFF
--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -43,6 +43,8 @@ class SnippetPlugin(CMSPluginBase):
             content = ('<pre>\n' +
                        '\n'.join(map(lambda x: escape(str(x)), sys.exc_info())) +
                        '\n</pre>')
+            import traceback
+            content += '\n<pre>\n' + escape(traceback.format_exc()) + '\n</pre>\n'
         context.update({
             'content': mark_safe(content),
         })

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -32,10 +32,11 @@ class SnippetPlugin(CMSPluginBase):
                 context.update({
                     'html': mark_safe(instance.snippet.html)
                 })
-                content = t.render(Context(context))
             else:
                 t = template.Template(instance.snippet.html)
-                content = t.render(Context(context))
+            if not isinstance(context, Context):
+                raise BadType("context should be a Context, not a " + str(type(context)))
+            content = t.render(context)
         except template.TemplateDoesNotExist:
             content = _('Template %(template)s does not exist.') % {
                 'template': instance.snippet.template}

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -5,6 +5,7 @@ from django import template
 from django.conf import settings
 from django.template.context import Context
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
@@ -39,8 +40,9 @@ class SnippetPlugin(CMSPluginBase):
             content = _('Template %(template)s does not exist.') % {
                 'template': instance.snippet.template}
         except Exception:
-            exc = sys.exc_info()[0]
-            content = str(exc)
+            content = ('<pre>\n' +
+                       '\n'.join(map(lambda x: escape(str(x)), sys.exc_info())) +
+                       '\n<pre>')
         context.update({
             'content': mark_safe(content),
         })

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -20,6 +20,7 @@ class SnippetPlugin(CMSPluginBase):
     render_template = 'djangocms_snippet/snippet.html'
     text_enabled = True
     text_editor_preview = False
+    cache = False
 
     def render(self, context, instance, placeholder):
         context.update({

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -42,7 +42,7 @@ class SnippetPlugin(CMSPluginBase):
         except Exception:
             content = ('<pre>\n' +
                        '\n'.join(map(lambda x: escape(str(x)), sys.exc_info())) +
-                       '\n<pre>')
+                       '\n</pre>')
         context.update({
             'content': mark_safe(content),
         })

--- a/djangocms_snippet/templatetags/snippet_tags.py
+++ b/djangocms_snippet/templatetags/snippet_tags.py
@@ -90,10 +90,11 @@ class SnippetFragment(template.Node):
                 context.update({
                     'html': mark_safe(instance.html)
                 })
-                content = t.render(template.Context(context))
             else:
                 t = template.Template(instance.html)
-                content = t.render(template.Context(context))
+            if not isinstance(context, template.Context):
+                raise BadType("context should be a Context, not a " + str(type(context)))
+            content = t.render(context)
         except template.TemplateDoesNotExist:
             content = _('Template %(template)s does not exist.') % {
                 'template': instance.template}


### PR DESCRIPTION
1) escape exception content like
  <type 'exceptions.ValueError'> or <class 'django.template.exceptions.TemplateSyntaxError'>
2) output the explicit part of the exception like
  Invalid block tag on line 3: 'foo_bar'. Did you forget to register or load this tag?