### PR TITLE
Issue #42 solution: change six (not imported by default in django3) to django.utils.six

### DIFF
--- a/djangocms_snippet/templatetags/snippet_tags.py
+++ b/djangocms_snippet/templatetags/snippet_tags.py
@@ -2,10 +2,10 @@
 """
 Snippet template tags
 """
-from django.utils import six
 from contextlib import contextmanager
 
 from django import template
+from django.utils import six
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 

--- a/djangocms_snippet/templatetags/snippet_tags.py
+++ b/djangocms_snippet/templatetags/snippet_tags.py
@@ -2,7 +2,7 @@
 """
 Snippet template tags
 """
-import six
+from django.utils import six
 from contextlib import contextmanager
 
 from django import template


### PR DESCRIPTION
This pull request solves issue #42 and Travis CI failures for other pull requests.