### PR TITLE
Fixed error message outputs in html page, plugin case

### DIFF
--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-import sys
-
 from django import template
 from django.conf import settings
 from django.template.context import Context
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
@@ -38,9 +37,8 @@ class SnippetPlugin(CMSPluginBase):
         except template.TemplateDoesNotExist:
             content = _('Template %(template)s does not exist.') % {
                 'template': instance.snippet.template}
-        except Exception:
-            exc = sys.exc_info()[0]
-            content = str(exc)
+        except Exception as e:
+            content = escape(str(e))
         context.update({
             'content': mark_safe(content),
         })


### PR DESCRIPTION
If a buggy snippet was inserted as a plugin, an erroneous tag `<class 'django.template.base.TemplateSyntaxError'>` was inserted in the page, instead of the html-escaped message.

A fix would be to replace `sys.exc_info()[0]` with `sys.exc_info()[1]`. The proposed code put
_plugin_ code in-line with _templatetag_ code https://github.com/divio/djangocms-snippet/blob/master/djangocms_snippet/templatetags/snippet_tags.py#L101