### PR TITLE
Added parameter DJANGOCMS_SNIPPET_CACHE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,10 @@ to edit the snippet content. You can customize the
     DJANGOCMS_SNIPPET_THEME = 'github'
     DJANGOCMS_SNIPPET_MODE = 'html'
 
+If dynamic content is inserted (for example ``{% show_menu ... %}``), the plugin cache nust be disabled,
+please set ``DJANGOCMS_SNIPPET_CACHE`` to ``False`` in your settings::
+
+    DJANGOCMS_SNIPPET_CACHE = False # default value is True
 
 Template tag
 ------------

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ to edit the snippet content. You can customize the
     DJANGOCMS_SNIPPET_THEME = 'github'
     DJANGOCMS_SNIPPET_MODE = 'html'
 
-If dynamic content is inserted (for example ``{% show_menu ... %}``), the plugin cache nust be disabled,
+If dynamic content is inserted (for example ``{% show_menu ... %}``), the plugin cache must be disabled,
 please set ``DJANGOCMS_SNIPPET_CACHE`` to ``False`` in your settings::
 
     DJANGOCMS_SNIPPET_CACHE = False # default value is True

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -19,6 +19,7 @@ class SnippetPlugin(CMSPluginBase):
     render_template = 'djangocms_snippet/snippet.html'
     text_enabled = True
     text_editor_preview = False
+    cache = getattr(settings, 'DJANGOCMS_SNIPPET_CACHE', True)
 
     def render(self, context, instance, placeholder):
         context.update({

--- a/djangocms_snippet/templatetags/snippet_tags.py
+++ b/djangocms_snippet/templatetags/snippet_tags.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 from django import template
 from django.utils import six
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
@@ -98,7 +99,7 @@ class SnippetFragment(template.Node):
             content = _('Template %(template)s does not exist.') % {
                 'template': instance.template}
         except Exception as e:
-            content = str(e)
+            content = escape(str(e))
             if self.parse_until:
                 # In case we are running 'exceptionless'
                 # Re-raise exception in order not to get the


### PR DESCRIPTION
This is issue #37 fix.

If dynamic content is inserted, for example ``{% show_menu ... %}``, the plugin cache must be disabled.

With this code, the parameter ``DJANGOCMS_SNIPPET_CACHE`` can be set to ``False`` in ``settings.py`` file. Default value remains equal to ``True``.