### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_snippet/migrations/0001_initial.py
+++ b/djangocms_snippet/migrations/0001_initial.py
@@ -29,8 +29,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SnippetPtr',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
-                ('snippet', models.ForeignKey(to='djangocms_snippet.Snippet')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
+                ('snippet', models.ForeignKey(to='djangocms_snippet.Snippet', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'Snippet',

--- a/djangocms_snippet/models.py
+++ b/djangocms_snippet/models.py
@@ -64,9 +64,10 @@ class SnippetPtr(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
-    snippet = models.ForeignKey(Snippet)
+    snippet = models.ForeignKey(Snippet, on_delete=models.CASCADE)
 
     search_fields = ['snippet__html'] if SEARCH_ENABLED else []
 


### PR DESCRIPTION
Squashing some incompatibilities between Django 1.11 and 2.0.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.