### PR TITLE
Bumped version to 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.3.0 (unreleased)
+2.3.0 (2020-01-29)
 ==================
 
 * Added support for Django 3.0
@@ -12,6 +12,7 @@ Changelog
 * Added further tests to raise coverage
 * Fixed smaller issues found during testing
 * Fixed alt attribute not rendering correctly
+* Fixed missing html variable not present in context
 
 
 2.2.0 (2019-05-06)

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'


### PR DESCRIPTION
* Added support for Django 3.0
* Fixed an issue where render requires a dict instead of a context
* Added ``DJANGOCMS_SNIPPET_CACHE`` cache settings for snippets
* Added further tests to raise coverage
* Fixed smaller issues found during testing
* Fixed alt attribute not rendering correctly
* Fixed missing html variable not present in context